### PR TITLE
Update testrail-mocha-reporter.js

### DIFF
--- a/src/testrail-mocha-reporter.js
+++ b/src/testrail-mocha-reporter.js
@@ -8,7 +8,7 @@ const getenv = require("getenv");
 require("dotenv").config();
 
 function getResultBody(test, caseId) {
-  let comment = `Duration: ${test.duration}ms`;
+  let comment = `Execution duration: ${test.duration}ms`;
   if (getenv.bool("CIRCLECI", false)) {
     comment = `
       ${comment}
@@ -22,7 +22,7 @@ function getResultBody(test, caseId) {
     case_id: caseId,
     status_id: test.state === "passed" ? 1 : 5,
     comment,
-    elapsed: test.duration,
+    elapsed: test.duration / 1000 + "s",
     version: getenv("TESTRAIL_RESULT_VERSION", "n/a")
   };
 }


### PR DESCRIPTION
Updates to the testrail-mocha-reporter.js file

1. To reflect Execution duration in getResultsBody 
2. Change to the test.duration to show the duration in seconds, as it was showing the time for a single test in days and hours.

![image](https://user-images.githubusercontent.com/26702883/231952297-2437f826-1000-4d6a-8ee9-f85bc85cd6f9.png)
